### PR TITLE
Fix: Fix python files not being installed correctly in `bf2stats-3.1.0` variant

### DIFF
--- a/generate/templates/Dockerfile.ps1
+++ b/generate/templates/Dockerfile.ps1
@@ -65,9 +65,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -
 RUN curl -ssLO https://github.com/BF2Statistics/StatsPython/archive/2197486.zip
 RUN sha256sum 2197486.zip | grep '^881ddc8f77a573be661f68a146883bc5e23b3d1b1a4d4323496d66d405744232 '
 RUN unzip 2197486.zip -d 2197486
-RUN rm -rf /server/bf2/python/
-RUN mkdir -p /server/bf2/python
-RUN cp -rf 2197486/*/. /server/bf2/python
+RUN cp -r 2197486/*/. /server/bf2/python/bf2/
 
 
 "@

--- a/variants/v1.5.3153.0-bf2stats-3.1.0/Dockerfile
+++ b/variants/v1.5.3153.0-bf2stats-3.1.0/Dockerfile
@@ -31,9 +31,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -
 RUN curl -ssLO https://github.com/BF2Statistics/StatsPython/archive/2197486.zip
 RUN sha256sum 2197486.zip | grep '^881ddc8f77a573be661f68a146883bc5e23b3d1b1a4d4323496d66d405744232 '
 RUN unzip 2197486.zip -d 2197486
-RUN rm -rf /server/bf2/python/
-RUN mkdir -p /server/bf2/python
-RUN cp -rf 2197486/*/. /server/bf2/python
+RUN cp -r 2197486/*/. /server/bf2/python/bf2/
 
 FROM ubuntu:16.04 AS final
 COPY --from=install /server /server


### PR DESCRIPTION
The server crashes with:

```
bf2stats-bf2-1  | FATAL ERROR: Debug assertion failed!
bf2stats-bf2-1  |
bf2stats-bf2-1  | Version: 1.5.3153-802.0 Build date:implement unix date here
bf2stats-bf2-1  | Module: Python
bf2stats-bf2-1  | File: Game/Python/PythonHost.cpp
bf2stats-bf2-1  | Line: 257
bf2stats-bf2-1  |
bf2stats-bf2-1  | Text: couldn't import the bf2 module:
bf2stats-bf2-1  |
bf2stats-bf2-1  | Current confile:
bf2stats-bf2-1  |
bf2stats-bf2-1 exited with code 1
bf2stats-bf2-1 exited with code 0
```