### PR TITLE
Docs (examples): Fix spoofed DNS in examples

### DIFF
--- a/docs/examples/v1.5-bf2all64-esai-optimized-strategies/docker-compose.yml
+++ b/docs/examples/v1.5-bf2all64-esai-optimized-strategies/docker-compose.yml
@@ -18,16 +18,16 @@ services:
       - 29900:29900/udp
     extra_hosts:
       - battlefield2.available.gamespy.com:192.168.1.100 # Your master server IP
-      - battlefield2.master.gamespy.com:92.51.181.102 # Your master server IP
-      - battlefield2.ms14.gamespy.com:92.51.181.102 # Your master server IP
-      - master.gamespy.com:92.51.181.102 # Your master server IP
-      - motd.gamespy.com:92.51.181.102 # Your master server IP
-      - gpsp.gamespy.com:92.51.181.102 # Your master server IP
-      - gpcm.gamespy.com:92.51.181.102 # Your master server IP
-      - gamespy.com:92.51.181.102 # Your master server IP
-      - bf2web.gamespy.com:92.51.180.45 # Your ASP web server IP
-      - gamestats.gamespy.com:92.51.180.45 # Your ASP web server IP
-      - eapusher.dice.se:92.51.180.45 # Your ASP web server IP
+      - battlefield2.master.gamespy.com:192.168.1.100 # Your master server IP
+      - battlefield2.ms14.gamespy.com:192.168.1.100 # Your master server IP
+      - master.gamespy.com:192.168.1.100 # Your master server IP
+      - motd.gamespy.com:192.168.1.100 # Your master server IP
+      - gpsp.gamespy.com:192.168.1.100 # Your master server IP
+      - gpcm.gamespy.com:192.168.1.100 # Your master server IP
+      - gamespy.com:192.168.1.100 # Your master server IP
+      - bf2web.gamespy.com:192.168.1.100 # Your ASP web server IP
+      - gamestats.gamespy.com:192.168.1.100 # Your ASP web server IP
+      - eapusher.dice.se:192.168.1.100 # Your ASP web server IP
     networks:
       - default
     healthcheck:

--- a/docs/examples/v1.5-bf2all64/docker-compose.yml
+++ b/docs/examples/v1.5-bf2all64/docker-compose.yml
@@ -15,16 +15,16 @@ services:
       - 29900:29900/udp
     extra_hosts:
       - battlefield2.available.gamespy.com:192.168.1.100 # Your master server IP
-      - battlefield2.master.gamespy.com:92.51.181.102 # Your master server IP
-      - battlefield2.ms14.gamespy.com:92.51.181.102 # Your master server IP
-      - master.gamespy.com:92.51.181.102 # Your master server IP
-      - motd.gamespy.com:92.51.181.102 # Your master server IP
-      - gpsp.gamespy.com:92.51.181.102 # Your master server IP
-      - gpcm.gamespy.com:92.51.181.102 # Your master server IP
-      - gamespy.com:92.51.181.102 # Your master server IP
-      - bf2web.gamespy.com:92.51.180.45 # Your ASP web server IP
-      - gamestats.gamespy.com:92.51.180.45 # Your ASP web server IP
-      - eapusher.dice.se:92.51.180.45 # Your ASP web server IP
+      - battlefield2.master.gamespy.com:192.168.1.100 # Your master server IP
+      - battlefield2.ms14.gamespy.com:192.168.1.100 # Your master server IP
+      - master.gamespy.com:192.168.1.100 # Your master server IP
+      - motd.gamespy.com:192.168.1.100 # Your master server IP
+      - gpsp.gamespy.com:192.168.1.100 # Your master server IP
+      - gpcm.gamespy.com:192.168.1.100 # Your master server IP
+      - gamespy.com:192.168.1.100 # Your master server IP
+      - bf2web.gamespy.com:192.168.1.100 # Your ASP web server IP
+      - gamestats.gamespy.com:192.168.1.100 # Your ASP web server IP
+      - eapusher.dice.se:192.168.1.100 # Your ASP web server IP
     networks:
       - default
     healthcheck:

--- a/docs/examples/v1.5-bf2hub-spoofed/docker-compose.yml
+++ b/docs/examples/v1.5-bf2hub-spoofed/docker-compose.yml
@@ -1,7 +1,6 @@
 version: '2.2'
 services:
-  # This is identical to the `v1.5-bf2hub` example
-  # It runs the official BF2 1.5 dedicated server binaries, and spoofs Gamespy DNS to use BF2Hub as the master server and the ASP web server
+  # This is identical to the `v1.5-bf2hub` example, except that it runs the official BF2 1.5 dedicated server binaries, and spoofs Gamespy DNS to use BF2Hub as the master server and the ASP web server
   # Server will be unranked since there is no custom ASP web server stats system
   bf2:
     image: startersclan/docker-bf2:v1.5.3153.0

--- a/docs/examples/v1.5-bf2stats-2/docker-compose.yml
+++ b/docs/examples/v1.5-bf2stats-2/docker-compose.yml
@@ -18,16 +18,16 @@ services:
       - 29900:29900/udp
     extra_hosts:
       - battlefield2.available.gamespy.com:192.168.1.100 # Your master server IP
-      - battlefield2.master.gamespy.com:92.51.181.102 # Your master server IP
-      - battlefield2.ms14.gamespy.com:92.51.181.102 # Your master server IP
-      - master.gamespy.com:92.51.181.102 # Your master server IP
-      - motd.gamespy.com:92.51.181.102 # Your master server IP
-      - gpsp.gamespy.com:92.51.181.102 # Your master server IP
-      - gpcm.gamespy.com:92.51.181.102 # Your master server IP
-      - gamespy.com:92.51.181.102 # Your master server IP
-      - bf2web.gamespy.com:92.51.180.45 # Your ASP web server IP
-      - gamestats.gamespy.com:92.51.180.45 # Your ASP web server IP
-      - eapusher.dice.se:92.51.180.45 # Your ASP web server IP
+      - battlefield2.master.gamespy.com:192.168.1.100 # Your master server IP
+      - battlefield2.ms14.gamespy.com:192.168.1.100 # Your master server IP
+      - master.gamespy.com:192.168.1.100 # Your master server IP
+      - motd.gamespy.com:192.168.1.100 # Your master server IP
+      - gpsp.gamespy.com:192.168.1.100 # Your master server IP
+      - gpcm.gamespy.com:192.168.1.100 # Your master server IP
+      - gamespy.com:192.168.1.100 # Your master server IP
+      - bf2web.gamespy.com:192.168.1.100 # Your ASP web server IP
+      - gamestats.gamespy.com:192.168.1.100 # Your ASP web server IP
+      - eapusher.dice.se:192.168.1.100 # Your ASP web server IP
     networks:
       - default
     healthcheck:

--- a/docs/examples/v1.5-bf2stats-3/docker-compose.yml
+++ b/docs/examples/v1.5-bf2stats-3/docker-compose.yml
@@ -18,6 +18,18 @@ services:
       - 29900:29900/udp
     networks:
       - default
+    extra_hosts:
+      - battlefield2.available.gamespy.com:192.168.1.100 # Your master server IP
+      - battlefield2.master.gamespy.com:192.168.1.100 # Your master server IP
+      - battlefield2.ms14.gamespy.com:192.168.1.100 # Your master server IP
+      - master.gamespy.com:192.168.1.100 # Your master server IP
+      - motd.gamespy.com:192.168.1.100 # Your master server IP
+      - gpsp.gamespy.com:192.168.1.100 # Your master server IP
+      - gpcm.gamespy.com:192.168.1.100 # Your master server IP
+      - gamespy.com:192.168.1.100 # Your master server IP
+      - bf2web.gamespy.com:192.168.1.100 # Your ASP web server IP
+      - gamestats.gamespy.com:192.168.1.100 # Your ASP web server IP
+      - eapusher.dice.se:192.168.1.100 # Your ASP web server IP
     healthcheck:
       test: /healthcheck localhost 29900
     tty: true


### PR DESCRIPTION
Certain examples' `docker-compose.yml` had `extra_hosts` containing a mix of private IPs and `bf2hub.com` IPs, instead of just being private IPs.

Now these examples are fixed to contain only private IPs, to be clear that the bf2 server requires a private master server.