### PR TITLE
Docs (examples): Disable debug logging in `Bf2StatisticsConfig-custom.py` for some examples

### DIFF
--- a/docs/examples/v1.5-bf2hub-bf2stats-2/config/bf2/python/bf2/BF2StatisticsConfig-custom.py
+++ b/docs/examples/v1.5-bf2hub-bf2stats-2/config/bf2/python/bf2/BF2StatisticsConfig-custom.py
@@ -9,7 +9,7 @@
 # ------------------------------------------------------------------------------
 # Debug Logging
 # ------------------------------------------------------------------------------
-debug_enable = 1
+debug_enable = 0
 debug_log_path = 'python/bf2/logs'		# Relative from BF2 base folder
 debug_fraglog_enable = 0				# Detailed 'Fragalyzer' Logs
 

--- a/docs/examples/v1.5-bf2hub-bf2stats-3/config/bf2/python/bf2/BF2StatisticsConfig-custom.py
+++ b/docs/examples/v1.5-bf2hub-bf2stats-3/config/bf2/python/bf2/BF2StatisticsConfig-custom.py
@@ -9,7 +9,7 @@
 # ------------------------------------------------------------------------------
 # Debug Logging
 # ------------------------------------------------------------------------------
-debug_enable = 1
+debug_enable = 0
 debug_log_path = 'python/bf2/logs'		# Relative from BF2 base folder
 debug_fraglog_enable = 0				# Detailed 'Fragalyzer' Logs (requires existing folder "mods/<ModName>/logs/")
 

--- a/docs/examples/v1.5-bf2stats-2/config/bf2/python/bf2/BF2StatisticsConfig-custom.py
+++ b/docs/examples/v1.5-bf2stats-2/config/bf2/python/bf2/BF2StatisticsConfig-custom.py
@@ -9,7 +9,7 @@
 # ------------------------------------------------------------------------------
 # Debug Logging
 # ------------------------------------------------------------------------------
-debug_enable = 1
+debug_enable = 0
 debug_log_path = 'python/bf2/logs'		# Relative from BF2 base folder
 debug_fraglog_enable = 0				# Detailed 'Fragalyzer' Logs
 

--- a/docs/examples/v1.5-bf2stats-3/config/bf2/python/bf2/BF2StatisticsConfig-custom.py
+++ b/docs/examples/v1.5-bf2stats-3/config/bf2/python/bf2/BF2StatisticsConfig-custom.py
@@ -9,7 +9,7 @@
 # ------------------------------------------------------------------------------
 # Debug Logging
 # ------------------------------------------------------------------------------
-debug_enable = 1
+debug_enable = 0
 debug_log_path = 'python/bf2/logs'		# Relative from BF2 base folder
 debug_fraglog_enable = 0				# Detailed 'Fragalyzer' Logs (requires existing folder "mods/<ModName>/logs/")
 


### PR DESCRIPTION
Debug logs should only be enabled when needed.