### PR TITLE
Fix (ci): Disable `docker` cache entirely

### DIFF
--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -41,14 +41,14 @@ jobs:
       id: buildx
       uses: docker/setup-buildx-action@master
 
-    - name: Cache Docker layers
-      uses: actions/cache@v3
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}
-          ${{ runner.os }}-buildx-
+    # - name: Cache Docker layers
+    #   uses: actions/cache@v3
+    #   with:
+    #     path: /tmp/.buildx-cache
+    #     key: ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}-${{ github.sha }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}
+    #       ${{ runner.os }}-buildx-
 
     - name: Prepare
       id: prep
@@ -99,8 +99,8 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     - name: Build and push (master)
       id: docker_build_master
@@ -114,8 +114,8 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     - name: Build and push (release)
       id: docker_build_release
@@ -130,16 +130,16 @@ jobs:
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
           ${{ github.repository }}:latest
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # Temp fix
     # https://github.com/docker/build-push-action/issues/252
     # https://github.com/moby/buildkit/issues/1896
-    - name: Move cache
-      run: |
-        rm -rf /tmp/.buildx-cache
-        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+    # - name: Move cache
+    #   run: |
+    #     rm -rf /tmp/.buildx-cache
+    #     mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
     - name: List docker images
       run: docker images
@@ -178,14 +178,14 @@ jobs:
       id: buildx
       uses: docker/setup-buildx-action@master
 
-    - name: Cache Docker layers
-      uses: actions/cache@v3
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}
-          ${{ runner.os }}-buildx-
+    # - name: Cache Docker layers
+    #   uses: actions/cache@v3
+    #   with:
+    #     path: /tmp/.buildx-cache
+    #     key: ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}-${{ github.sha }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}
+    #       ${{ runner.os }}-buildx-
 
     - name: Prepare
       id: prep
@@ -236,8 +236,8 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     - name: Build and push (master)
       id: docker_build_master
@@ -251,8 +251,8 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     - name: Build and push (release)
       id: docker_build_release
@@ -266,16 +266,16 @@ jobs:
           ${{ github.repository }}:${{ env.VARIANT_TAG }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # Temp fix
     # https://github.com/docker/build-push-action/issues/252
     # https://github.com/moby/buildkit/issues/1896
-    - name: Move cache
-      run: |
-        rm -rf /tmp/.buildx-cache
-        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+    # - name: Move cache
+    #   run: |
+    #     rm -rf /tmp/.buildx-cache
+    #     mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
     - name: List docker images
       run: docker images
@@ -314,14 +314,14 @@ jobs:
       id: buildx
       uses: docker/setup-buildx-action@master
 
-    - name: Cache Docker layers
-      uses: actions/cache@v3
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}
-          ${{ runner.os }}-buildx-
+    # - name: Cache Docker layers
+    #   uses: actions/cache@v3
+    #   with:
+    #     path: /tmp/.buildx-cache
+    #     key: ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}-${{ github.sha }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}
+    #       ${{ runner.os }}-buildx-
 
     - name: Prepare
       id: prep
@@ -372,8 +372,8 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     - name: Build and push (master)
       id: docker_build_master
@@ -387,8 +387,8 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     - name: Build and push (release)
       id: docker_build_release
@@ -402,16 +402,16 @@ jobs:
           ${{ github.repository }}:${{ env.VARIANT_TAG }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # Temp fix
     # https://github.com/docker/build-push-action/issues/252
     # https://github.com/moby/buildkit/issues/1896
-    - name: Move cache
-      run: |
-        rm -rf /tmp/.buildx-cache
-        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+    # - name: Move cache
+    #   run: |
+    #     rm -rf /tmp/.buildx-cache
+    #     mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
     - name: List docker images
       run: docker images
@@ -450,14 +450,14 @@ jobs:
       id: buildx
       uses: docker/setup-buildx-action@master
 
-    - name: Cache Docker layers
-      uses: actions/cache@v3
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}
-          ${{ runner.os }}-buildx-
+    # - name: Cache Docker layers
+    #   uses: actions/cache@v3
+    #   with:
+    #     path: /tmp/.buildx-cache
+    #     key: ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}-${{ github.sha }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}
+    #       ${{ runner.os }}-buildx-
 
     - name: Prepare
       id: prep
@@ -508,8 +508,8 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     - name: Build and push (master)
       id: docker_build_master
@@ -523,8 +523,8 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     - name: Build and push (release)
       id: docker_build_release
@@ -538,16 +538,16 @@ jobs:
           ${{ github.repository }}:${{ env.VARIANT_TAG }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # Temp fix
     # https://github.com/docker/build-push-action/issues/252
     # https://github.com/moby/buildkit/issues/1896
-    - name: Move cache
-      run: |
-        rm -rf /tmp/.buildx-cache
-        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+    # - name: Move cache
+    #   run: |
+    #     rm -rf /tmp/.buildx-cache
+    #     mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
     - name: List docker images
       run: docker images
@@ -586,14 +586,14 @@ jobs:
       id: buildx
       uses: docker/setup-buildx-action@master
 
-    - name: Cache Docker layers
-      uses: actions/cache@v3
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}
-          ${{ runner.os }}-buildx-
+    # - name: Cache Docker layers
+    #   uses: actions/cache@v3
+    #   with:
+    #     path: /tmp/.buildx-cache
+    #     key: ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}-${{ github.sha }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}
+    #       ${{ runner.os }}-buildx-
 
     - name: Prepare
       id: prep
@@ -644,8 +644,8 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     - name: Build and push (master)
       id: docker_build_master
@@ -659,8 +659,8 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     - name: Build and push (release)
       id: docker_build_release
@@ -674,16 +674,16 @@ jobs:
           ${{ github.repository }}:${{ env.VARIANT_TAG }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # Temp fix
     # https://github.com/docker/build-push-action/issues/252
     # https://github.com/moby/buildkit/issues/1896
-    - name: Move cache
-      run: |
-        rm -rf /tmp/.buildx-cache
-        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+    # - name: Move cache
+    #   run: |
+    #     rm -rf /tmp/.buildx-cache
+    #     mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
     - name: List docker images
       run: docker images
@@ -722,14 +722,14 @@ jobs:
       id: buildx
       uses: docker/setup-buildx-action@master
 
-    - name: Cache Docker layers
-      uses: actions/cache@v3
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}
-          ${{ runner.os }}-buildx-
+    # - name: Cache Docker layers
+    #   uses: actions/cache@v3
+    #   with:
+    #     path: /tmp/.buildx-cache
+    #     key: ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}-${{ github.sha }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}
+    #       ${{ runner.os }}-buildx-
 
     - name: Prepare
       id: prep
@@ -780,8 +780,8 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     - name: Build and push (master)
       id: docker_build_master
@@ -795,8 +795,8 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     - name: Build and push (release)
       id: docker_build_release
@@ -810,16 +810,16 @@ jobs:
           ${{ github.repository }}:${{ env.VARIANT_TAG }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # Temp fix
     # https://github.com/docker/build-push-action/issues/252
     # https://github.com/moby/buildkit/issues/1896
-    - name: Move cache
-      run: |
-        rm -rf /tmp/.buildx-cache
-        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+    # - name: Move cache
+    #   run: |
+    #     rm -rf /tmp/.buildx-cache
+    #     mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
     - name: List docker images
       run: docker images
@@ -858,14 +858,14 @@ jobs:
       id: buildx
       uses: docker/setup-buildx-action@master
 
-    - name: Cache Docker layers
-      uses: actions/cache@v3
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}
-          ${{ runner.os }}-buildx-
+    # - name: Cache Docker layers
+    #   uses: actions/cache@v3
+    #   with:
+    #     path: /tmp/.buildx-cache
+    #     key: ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}-${{ github.sha }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}
+    #       ${{ runner.os }}-buildx-
 
     - name: Prepare
       id: prep
@@ -916,8 +916,8 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     - name: Build and push (master)
       id: docker_build_master
@@ -931,8 +931,8 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     - name: Build and push (release)
       id: docker_build_release
@@ -946,16 +946,16 @@ jobs:
           ${{ github.repository }}:${{ env.VARIANT_TAG }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # Temp fix
     # https://github.com/docker/build-push-action/issues/252
     # https://github.com/moby/buildkit/issues/1896
-    - name: Move cache
-      run: |
-        rm -rf /tmp/.buildx-cache
-        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+    # - name: Move cache
+    #   run: |
+    #     rm -rf /tmp/.buildx-cache
+    #     mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
     - name: List docker images
       run: docker images
@@ -994,14 +994,14 @@ jobs:
       id: buildx
       uses: docker/setup-buildx-action@master
 
-    - name: Cache Docker layers
-      uses: actions/cache@v3
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}
-          ${{ runner.os }}-buildx-
+    # - name: Cache Docker layers
+    #   uses: actions/cache@v3
+    #   with:
+    #     path: /tmp/.buildx-cache
+    #     key: ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}-${{ github.sha }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}
+    #       ${{ runner.os }}-buildx-
 
     - name: Prepare
       id: prep
@@ -1052,8 +1052,8 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     - name: Build and push (master)
       id: docker_build_master
@@ -1067,8 +1067,8 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     - name: Build and push (release)
       id: docker_build_release
@@ -1082,16 +1082,16 @@ jobs:
           ${{ github.repository }}:${{ env.VARIANT_TAG }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # Temp fix
     # https://github.com/docker/build-push-action/issues/252
     # https://github.com/moby/buildkit/issues/1896
-    - name: Move cache
-      run: |
-        rm -rf /tmp/.buildx-cache
-        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+    # - name: Move cache
+    #   run: |
+    #     rm -rf /tmp/.buildx-cache
+    #     mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
     - name: List docker images
       run: docker images
@@ -1130,14 +1130,14 @@ jobs:
       id: buildx
       uses: docker/setup-buildx-action@master
 
-    - name: Cache Docker layers
-      uses: actions/cache@v3
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}
-          ${{ runner.os }}-buildx-
+    # - name: Cache Docker layers
+    #   uses: actions/cache@v3
+    #   with:
+    #     path: /tmp/.buildx-cache
+    #     key: ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}-${{ github.sha }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}
+    #       ${{ runner.os }}-buildx-
 
     - name: Prepare
       id: prep
@@ -1188,8 +1188,8 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     - name: Build and push (master)
       id: docker_build_master
@@ -1203,8 +1203,8 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     - name: Build and push (release)
       id: docker_build_release
@@ -1218,16 +1218,16 @@ jobs:
           ${{ github.repository }}:${{ env.VARIANT_TAG }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # Temp fix
     # https://github.com/docker/build-push-action/issues/252
     # https://github.com/moby/buildkit/issues/1896
-    - name: Move cache
-      run: |
-        rm -rf /tmp/.buildx-cache
-        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+    # - name: Move cache
+    #   run: |
+    #     rm -rf /tmp/.buildx-cache
+    #     mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
     - name: List docker images
       run: docker images
@@ -1266,14 +1266,14 @@ jobs:
       id: buildx
       uses: docker/setup-buildx-action@master
 
-    - name: Cache Docker layers
-      uses: actions/cache@v3
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}
-          ${{ runner.os }}-buildx-
+    # - name: Cache Docker layers
+    #   uses: actions/cache@v3
+    #   with:
+    #     path: /tmp/.buildx-cache
+    #     key: ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}-${{ github.sha }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}
+    #       ${{ runner.os }}-buildx-
 
     - name: Prepare
       id: prep
@@ -1324,8 +1324,8 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     - name: Build and push (master)
       id: docker_build_master
@@ -1339,8 +1339,8 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     - name: Build and push (release)
       id: docker_build_release
@@ -1354,16 +1354,16 @@ jobs:
           ${{ github.repository }}:${{ env.VARIANT_TAG }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # Temp fix
     # https://github.com/docker/build-push-action/issues/252
     # https://github.com/moby/buildkit/issues/1896
-    - name: Move cache
-      run: |
-        rm -rf /tmp/.buildx-cache
-        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+    # - name: Move cache
+    #   run: |
+    #     rm -rf /tmp/.buildx-cache
+    #     mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
     - name: List docker images
       run: docker images
@@ -1402,14 +1402,14 @@ jobs:
       id: buildx
       uses: docker/setup-buildx-action@master
 
-    - name: Cache Docker layers
-      uses: actions/cache@v3
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}
-          ${{ runner.os }}-buildx-
+    # - name: Cache Docker layers
+    #   uses: actions/cache@v3
+    #   with:
+    #     path: /tmp/.buildx-cache
+    #     key: ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}-${{ github.sha }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}
+    #       ${{ runner.os }}-buildx-
 
     - name: Prepare
       id: prep
@@ -1460,8 +1460,8 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     - name: Build and push (master)
       id: docker_build_master
@@ -1475,8 +1475,8 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     - name: Build and push (release)
       id: docker_build_release
@@ -1490,16 +1490,16 @@ jobs:
           ${{ github.repository }}:${{ env.VARIANT_TAG }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # Temp fix
     # https://github.com/docker/build-push-action/issues/252
     # https://github.com/moby/buildkit/issues/1896
-    - name: Move cache
-      run: |
-        rm -rf /tmp/.buildx-cache
-        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+    # - name: Move cache
+    #   run: |
+    #     rm -rf /tmp/.buildx-cache
+    #     mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
     - name: List docker images
       run: docker images
@@ -1538,14 +1538,14 @@ jobs:
       id: buildx
       uses: docker/setup-buildx-action@master
 
-    - name: Cache Docker layers
-      uses: actions/cache@v3
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}
-          ${{ runner.os }}-buildx-
+    # - name: Cache Docker layers
+    #   uses: actions/cache@v3
+    #   with:
+    #     path: /tmp/.buildx-cache
+    #     key: ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}-${{ github.sha }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}
+    #       ${{ runner.os }}-buildx-
 
     - name: Prepare
       id: prep
@@ -1596,8 +1596,8 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     - name: Build and push (master)
       id: docker_build_master
@@ -1611,8 +1611,8 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     - name: Build and push (release)
       id: docker_build_release
@@ -1626,16 +1626,16 @@ jobs:
           ${{ github.repository }}:${{ env.VARIANT_TAG }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # Temp fix
     # https://github.com/docker/build-push-action/issues/252
     # https://github.com/moby/buildkit/issues/1896
-    - name: Move cache
-      run: |
-        rm -rf /tmp/.buildx-cache
-        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+    # - name: Move cache
+    #   run: |
+    #     rm -rf /tmp/.buildx-cache
+    #     mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
     - name: List docker images
       run: docker images
@@ -1674,14 +1674,14 @@ jobs:
       id: buildx
       uses: docker/setup-buildx-action@master
 
-    - name: Cache Docker layers
-      uses: actions/cache@v3
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}
-          ${{ runner.os }}-buildx-
+    # - name: Cache Docker layers
+    #   uses: actions/cache@v3
+    #   with:
+    #     path: /tmp/.buildx-cache
+    #     key: ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}-${{ github.sha }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}
+    #       ${{ runner.os }}-buildx-
 
     - name: Prepare
       id: prep
@@ -1732,8 +1732,8 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     - name: Build and push (master)
       id: docker_build_master
@@ -1747,8 +1747,8 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     - name: Build and push (release)
       id: docker_build_release
@@ -1762,16 +1762,16 @@ jobs:
           ${{ github.repository }}:${{ env.VARIANT_TAG }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # Temp fix
     # https://github.com/docker/build-push-action/issues/252
     # https://github.com/moby/buildkit/issues/1896
-    - name: Move cache
-      run: |
-        rm -rf /tmp/.buildx-cache
-        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+    # - name: Move cache
+    #   run: |
+    #     rm -rf /tmp/.buildx-cache
+    #     mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
     - name: List docker images
       run: docker images
@@ -1810,14 +1810,14 @@ jobs:
       id: buildx
       uses: docker/setup-buildx-action@master
 
-    - name: Cache Docker layers
-      uses: actions/cache@v3
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}
-          ${{ runner.os }}-buildx-
+    # - name: Cache Docker layers
+    #   uses: actions/cache@v3
+    #   with:
+    #     path: /tmp/.buildx-cache
+    #     key: ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}-${{ github.sha }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}
+    #       ${{ runner.os }}-buildx-
 
     - name: Prepare
       id: prep
@@ -1868,8 +1868,8 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     - name: Build and push (master)
       id: docker_build_master
@@ -1883,8 +1883,8 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     - name: Build and push (release)
       id: docker_build_release
@@ -1898,16 +1898,16 @@ jobs:
           ${{ github.repository }}:${{ env.VARIANT_TAG }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # Temp fix
     # https://github.com/docker/build-push-action/issues/252
     # https://github.com/moby/buildkit/issues/1896
-    - name: Move cache
-      run: |
-        rm -rf /tmp/.buildx-cache
-        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+    # - name: Move cache
+    #   run: |
+    #     rm -rf /tmp/.buildx-cache
+    #     mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
     - name: List docker images
       run: docker images

--- a/generate/templates/.github/workflows/ci-master-pr.yml.ps1
+++ b/generate/templates/.github/workflows/ci-master-pr.yml.ps1
@@ -51,14 +51,14 @@ $VARIANTS | % {
       id: buildx
       uses: docker/setup-buildx-action@master
 
-    - name: Cache Docker layers
-      uses: actions/cache@v3
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}
-          ${{ runner.os }}-buildx-
+    # - name: Cache Docker layers
+    #   uses: actions/cache@v3
+    #   with:
+    #     path: /tmp/.buildx-cache
+    #     key: ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}-${{ github.sha }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-buildx-${{ env.VARIANT_TAG }}
+    #       ${{ runner.os }}-buildx-
 
     - name: Prepare
       id: prep
@@ -112,8 +112,8 @@ $VARIANTS | % {
         tags: |
           `${{ github.repository }}:`${{ env.VARIANT_TAG_WITH_REF }}
           `${{ github.repository }}:`${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     - name: Build and push (master)
       id: docker_build_master
@@ -127,8 +127,8 @@ $VARIANTS | % {
         tags: |
           `${{ github.repository }}:`${{ env.VARIANT_TAG_WITH_REF }}
           `${{ github.repository }}:`${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     - name: Build and push (release)
       id: docker_build_release
@@ -152,16 +152,16 @@ if ( $_['tag_as_latest'] ) {
 '@
 }
 @'
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        # cache-from: type=local,src=/tmp/.buildx-cache
+        # cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # Temp fix
     # https://github.com/docker/build-push-action/issues/252
     # https://github.com/moby/buildkit/issues/1896
-    - name: Move cache
-      run: |
-        rm -rf /tmp/.buildx-cache
-        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+    # - name: Move cache
+    #   run: |
+    #     rm -rf /tmp/.buildx-cache
+    #     mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
     - name: List docker images
       run: docker images


### PR DESCRIPTION
Caches are a few to several GB for each variant, which can actually end up slowing build jobs. For cache to speed up builds, `Dockerfile`s have to be rewritten for each variant cache to be small, i.e. `<1GB`.