### PR TITLE
Fix: Fix invalid `bf2stats-3.1.0` `.zip` archive URL

### DIFF
--- a/generate/templates/Dockerfile.ps1
+++ b/generate/templates/Dockerfile.ps1
@@ -135,19 +135,6 @@ RUN set -eux; \
 
     if ($c -match 'bf2stats-(3\.\d+\.\d+)') {
         $v = $matches[1]
-        if ($v -eq '3.1.0') {
-@"
-# Install bf2stats $v
-WORKDIR /root
-RUN set -eux; \
-    curl -sSLO https://github.com/BF2Statistics/StatsPython/archive/2197486.zip; \
-    sha256sum 2197486.zip | grep '^881ddc8f77a573be661f68a146883bc5e23b3d1b1a4d4323496d66d405744232 '; \
-    unzip 2197486.zip -d 2197486; \
-    cp -r 2197486/*/. /server/bf2/python/bf2/; \
-    rm -fv 2197486.zip;
-
-"@
-        } else {
 @"
 # Install bf2stats $v
 WORKDIR /root
@@ -160,7 +147,6 @@ RUN set -eux; \
 
 
 "@
-        }
     }
 
     if ($c -match 'fh2-(\d+\.\d+\.\d+)') {

--- a/variants/v1.5.3153.0-bf2all64-bf2stats-3.1.0/Dockerfile
+++ b/variants/v1.5.3153.0-bf2all64-bf2stats-3.1.0/Dockerfile
@@ -60,11 +60,12 @@ RUN set -eux; \
 # Install bf2stats 3.1.0
 WORKDIR /root
 RUN set -eux; \
-    curl -sSLO https://github.com/BF2Statistics/StatsPython/archive/2197486.zip; \
-    sha256sum 2197486.zip | grep '^881ddc8f77a573be661f68a146883bc5e23b3d1b1a4d4323496d66d405744232 '; \
-    unzip 2197486.zip -d 2197486; \
-    cp -r 2197486/*/. /server/bf2/python/bf2/; \
-    rm -fv 2197486.zip;
+    curl -sSLO https://github.com/startersclan/StatsPython/archive/refs/tags/3.1.0.zip; \
+    echo "ab6d0f2dc3c90223524a6d97dd3100796fdf266444b5cd2f066116b977d3551c  3.1.0.zip" | sha256sum -c -; \
+    unzip 3.1.0.zip -d extract; \
+    cp -r extract/*/. /server/bf2/python/bf2/; \
+    rm -fv 3.1.0.zip;
+
 # Install ESAI in all mods
 WORKDIR /root
 COPY ESAI-Standard-v4.2.zip ESAI-Standard-v4.2.zip

--- a/variants/v1.5.3153.0-bf2stats-3.1.0/Dockerfile
+++ b/variants/v1.5.3153.0-bf2stats-3.1.0/Dockerfile
@@ -45,11 +45,12 @@ RUN set -eux; \
 # Install bf2stats 3.1.0
 WORKDIR /root
 RUN set -eux; \
-    curl -sSLO https://github.com/BF2Statistics/StatsPython/archive/2197486.zip; \
-    sha256sum 2197486.zip | grep '^881ddc8f77a573be661f68a146883bc5e23b3d1b1a4d4323496d66d405744232 '; \
-    unzip 2197486.zip -d 2197486; \
-    cp -r 2197486/*/. /server/bf2/python/bf2/; \
-    rm -fv 2197486.zip;
+    curl -sSLO https://github.com/startersclan/StatsPython/archive/refs/tags/3.1.0.zip; \
+    echo "ab6d0f2dc3c90223524a6d97dd3100796fdf266444b5cd2f066116b977d3551c  3.1.0.zip" | sha256sum -c -; \
+    unzip 3.1.0.zip -d extract; \
+    cp -r extract/*/. /server/bf2/python/bf2/; \
+    rm -fv 3.1.0.zip;
+
 # Install ESAI in all mods
 WORKDIR /root
 COPY ESAI-Standard-v4.2.zip ESAI-Standard-v4.2.zip


### PR DESCRIPTION
The github organization https://github.com/BF2Statistics no longer exists, and the URL is broken.
